### PR TITLE
Update to support 1.20.6

### DIFF
--- a/Plugin/pom.xml
+++ b/Plugin/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>de.Linus122.TimeIsMoney</groupId>
 		<artifactId>parent</artifactId>
-		<version>1.9.10</version>
+		<version>1.9.11</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -111,7 +111,7 @@
 		<dependency>
 			<groupId>de.Linus122.TimeIsMoney</groupId>
 			<artifactId>Tools</artifactId>
-			<version>1.9.10</version>
+			<version>1.9.11</version>
 		</dependency>
         <dependency>
             <groupId>org.jetbrains</groupId>

--- a/Plugin/pom.xml
+++ b/Plugin/pom.xml
@@ -33,7 +33,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>2.4.3</version>
+				<version>3.6.0</version>
 				<executions>
 					<execution>
 						<phase>package</phase>
@@ -76,7 +76,7 @@
 		<dependency>
 			<groupId>org.spigotmc</groupId>
 			<artifactId>spigot-api</artifactId>
-			<version>1.18-R0.1-SNAPSHOT</version>
+			<version>1.20.6-R0.1-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/Plugin/pom.xml
+++ b/Plugin/pom.xml
@@ -33,7 +33,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>3.6.0</version>
+				<version>2.4.3</version>
 				<executions>
 					<execution>
 						<phase>package</phase>
@@ -76,7 +76,7 @@
 		<dependency>
 			<groupId>org.spigotmc</groupId>
 			<artifactId>spigot-api</artifactId>
-			<version>1.20.6-R0.1-SNAPSHOT</version>
+			<version>1.13.2-R0.1-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/Plugin/src/main/resources/plugin.yml
+++ b/Plugin/src/main/resources/plugin.yml
@@ -4,7 +4,7 @@ description: Gives money for online time
 author: Linus122
 website: "https://www.spigotmc.org/resources/time-is-money.12409/"
 main: de.Linus122.TimeIsMoney.Main
-api-version: 1.20.6
+api-version: 1.13.2
 
 depend: [Vault]
 softdepend: [Essentials, PlaceholderAPI]

--- a/Plugin/src/main/resources/plugin.yml
+++ b/Plugin/src/main/resources/plugin.yml
@@ -4,7 +4,7 @@ description: Gives money for online time
 author: Linus122
 website: "https://www.spigotmc.org/resources/time-is-money.12409/"
 main: de.Linus122.TimeIsMoney.Main
-api-version: 1.13
+api-version: 1.20.6
 
 depend: [Vault]
 softdepend: [Essentials, PlaceholderAPI]

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=5ATDE93C6J3WE&source=url)
 
 ## Welcome to the TimeIsMoney GitHub repository!
-TimeIsMoney is a Spigot plugin compatible with Spigot versions 1.7 through 1.18.*, that gives players money for their time online!
+TimeIsMoney is a Spigot plugin compatible with Spigot versions 1.7 through 1.20.6, that gives players money for their time online!
 
 In order for everyone to have the best experience possible, we have a few guidelines that everyone must follow.    
 - For all things on GitHub, please make sure you follow the [code of conduct](CODE_OF_CONDUCT.md).  

--- a/Tools/pom.xml
+++ b/Tools/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>de.Linus122.TimeIsMoney</groupId>
         <artifactId>parent</artifactId>
-        <version>1.9.10</version>
+        <version>1.9.11</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -54,8 +54,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>21</source>
+                    <target>21</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -54,8 +54,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>21</source>
-                    <target>21</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.Linus122.TimeIsMoney</groupId>
     <artifactId>parent</artifactId>
-    <version>1.9.10</version>
+    <version>1.9.11</version>
     <name>TimeIsMoney</name>
     <url>https://www.spigotmc.org/resources/time-is-money.12409/</url>
     <packaging>pom</packaging>


### PR DESCRIPTION
Updates:
- java source / target
- maven plugin (old was broken on java 21)
- Spigot api to 1.20.6
- (bumps version to 1.9.11)